### PR TITLE
Fixing bugs and updating release notes.

### DIFF
--- a/DepRegAttributes.Analyzer/AnalyzerReleases.Shipped.md
+++ b/DepRegAttributes.Analyzer/AnalyzerReleases.Shipped.md
@@ -1,7 +1,7 @@
 ﻿; Shipped analyzer releases
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
 
-## Release 7.0.1
+## Release 8.0.0
 
 ### New Rules
 
@@ -9,11 +9,4 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 ServiceRegistration001 | ServiceRegistration | Error | ServiceProviderAttributeAnalyzer
 ServiceRegistration002 | ServiceRegistration | Error | ServiceProviderAttributeAnalyzer
-
-## Release 7.0.3
-
-### New Rules
-
-Rule ID | Category | Severity | Notes
---------|----------|----------|-------
 ServiceRegistration003 | ServiceRegistration | Warning | ServiceProviderAttributeAnalyzer

--- a/DepRegAttributes/DepRegAttributes.csproj
+++ b/DepRegAttributes/DepRegAttributes.csproj
@@ -30,7 +30,7 @@
 		<NoPackageAnalysis>true</NoPackageAnalysis>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 
-		<PackageReleaseNotes>https://github.com/dalton-baker/DepRegAttributes/blob/master/ReleaseNotes.md</PackageReleaseNotes>
+		<PackageReleaseNotes>https://github.com/dalton-baker/DepRegAttributes/wiki/Version-8-Release-Notes</PackageReleaseNotes>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -43,9 +43,9 @@
 	<ItemGroup>
 		<None Update="tools\*.ps1" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath="" />
 		<None Include="..\README.md" Pack="true" PackagePath="" />
-		<None Include="..\ReleaseNotes.md" Pack="true" PackagePath="" />
 		<None Include="..\LICENSE" Pack="true" PackagePath="" />
 		<None Include="..\DepRegAttributes.Analyzer\AnalyzerReleases.Shipped.md" Pack="true" PackagePath="" />
+		<None Include="..\ReleaseNotes.md" />
 	</ItemGroup>
 
 	<Target Name="_AddAnalyzersToOutput">

--- a/DepRegAttributes/DepRegAttributes.csproj
+++ b/DepRegAttributes/DepRegAttributes.csproj
@@ -11,7 +11,7 @@
 	<PropertyGroup>
 		<PackageId>DBaker.DepRegAttributes</PackageId>
 		<Authors>dalton_s_baker</Authors>
-		<Version>7.0.8</Version>
+		<Version>8.0.0</Version>
 		<PackageProjectUrl>https://github.com/dalton-baker/DepRegAttributes</PackageProjectUrl>
 		<!--<PackageIconUrl>http://ICON_URL_HERE_OR_DELETE_THIS_LINE</PackageIconUrl>-->
 		<RepositoryUrl>https://github.com/dalton-baker/DepRegAttributes</RepositoryUrl>

--- a/DepRegAttributes/DepRegAttributes.csproj
+++ b/DepRegAttributes/DepRegAttributes.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+		<TargetFramework>netstandard2.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Nullable>enable</Nullable>
@@ -11,7 +11,7 @@
 	<PropertyGroup>
 		<PackageId>DBaker.DepRegAttributes</PackageId>
 		<Authors>dalton_s_baker</Authors>
-		<Version>7.0.7</Version>
+		<Version>17.0.10</Version>
 		<PackageProjectUrl>https://github.com/dalton-baker/DepRegAttributes</PackageProjectUrl>
 		<!--<PackageIconUrl>http://ICON_URL_HERE_OR_DELETE_THIS_LINE</PackageIconUrl>-->
 		<RepositoryUrl>https://github.com/dalton-baker/DepRegAttributes</RepositoryUrl>
@@ -34,8 +34,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.32" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0"/>
 		<ProjectReference Include="..\DepRegAttributes.Analyzer\DepRegAttributes.Analyzer.csproj">
 			<PrivateAssets>All</PrivateAssets>
 		</ProjectReference>
@@ -49,7 +48,7 @@
 		<None Include="..\DepRegAttributes.Analyzer\AnalyzerReleases.Shipped.md" Pack="true" PackagePath="" />
 	</ItemGroup>
 
-	<Target Name="_AddAnalyzersToOutput" Condition="'$(TargetFramework)' == 'netstandard2.0'">
+	<Target Name="_AddAnalyzersToOutput">
 		<ItemGroup>
 			<TfmSpecificPackageFile Include="$(OutputPath)\DepRegAttributes.Analyzer.dll" PackagePath="analyzers/dotnet/cs" />
 		</ItemGroup>

--- a/DepRegAttributes/DepRegAttributes.csproj
+++ b/DepRegAttributes/DepRegAttributes.csproj
@@ -11,7 +11,7 @@
 	<PropertyGroup>
 		<PackageId>DBaker.DepRegAttributes</PackageId>
 		<Authors>dalton_s_baker</Authors>
-		<Version>17.0.10</Version>
+		<Version>7.0.8</Version>
 		<PackageProjectUrl>https://github.com/dalton-baker/DepRegAttributes</PackageProjectUrl>
 		<!--<PackageIconUrl>http://ICON_URL_HERE_OR_DELETE_THIS_LINE</PackageIconUrl>-->
 		<RepositoryUrl>https://github.com/dalton-baker/DepRegAttributes</RepositoryUrl>

--- a/DepRegAttributes/RegisterAttributeBase.cs
+++ b/DepRegAttributes/RegisterAttributeBase.cs
@@ -15,13 +15,11 @@ public abstract class RegisterAttributeBase(ServiceLifetime serviceLifetime, par
     /// Used as a filter when registering services
     /// </summary>
     public object? Tag { get; set; }
-
-#if NET8_0_OR_GREATER
+    
     /// <summary>
     /// Use this to register a Keyed service 
     /// </summary>
     public object? Key { get; set; } = null;
-#endif
 
     /// <summary>
     /// The lifetime of the services registered by this attribute

--- a/DepRegAttributes/ServiceCollectionExtensions.cs
+++ b/DepRegAttributes/ServiceCollectionExtensions.cs
@@ -16,11 +16,11 @@ public static class ServiceCollectionExtensions
     /// <param name="tagFilters">The tags you want to register services for (optional)</param>
     /// <exception cref="CustomAttributeFormatException">Thrown when an attribute has a service type that is not valid for the implementation type.</exception>
     /// <returns>A reference to this instance after the opperation has completed.</returns>
-    [Obsolete("Replaced with AddByAttribute(params object[])")]
+    [Obsolete("Use AddByAttribute()")]
     public static IServiceCollection RegisterDependenciesByAttribute(
         this IServiceCollection services,
         params object[] tagFilters)
-        => services.AddByAttribute(tagFilters);
+        => services.AddByAttribute(Assembly.GetCallingAssembly(), tagFilters);
 
     /// <summary>
     /// Register services by attribute for a specific Assembly.
@@ -30,7 +30,7 @@ public static class ServiceCollectionExtensions
     /// <param name="tagFilters">The tags you want to register services for (optional)</param>
     /// <exception cref="CustomAttributeFormatException">Thrown when an attribute has a service type that is not valid for the implementation type.</exception>
     /// <returns>A reference to this instance after the opperation has completed.</returns>
-    [Obsolete("Replaced with AddByAttribute(Assembly, params object[])")]
+    [Obsolete("Use AddByAttribute()")]
     public static IServiceCollection RegisterDependenciesByAttribute(
         this IServiceCollection services,
         Assembly assembly,
@@ -95,7 +95,6 @@ public static class ServiceCollectionExtensions
             if (!implementationType.IsGenericType && !type.IsAssignableFrom(implementationType))
                 throw new CustomAttributeFormatException($"{implementationType.Name} cannot be registered as a {type.Name}.");
 
-#if NET8_0_OR_GREATER
             if (registerAttribute.Key is not null)
             {
                 if (type.Equals(firstType) || registerAttribute.ServiceLifetime is ServiceLifetime.Transient)
@@ -104,7 +103,6 @@ public static class ServiceCollectionExtensions
                     services.Add(new ServiceDescriptor(type, registerAttribute.Key, (sp, k) => sp.GetRequiredKeyedService(firstType, k), registerAttribute.ServiceLifetime));
                 continue;
             }
-#endif
 
             if (type.Equals(firstType) || registerAttribute.ServiceLifetime is ServiceLifetime.Transient)
                 services.Add(new ServiceDescriptor(type, implementationType, registerAttribute.ServiceLifetime));

--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ serviceCollection.AddByAttribute(assembly, "Key1", "Key2");
 
 
 ## Keyed Services
-For .NET 8.0 or higher projects, you can use the new keyed services feature. You can read more about keyed services in the [.NET 8 Release Notes](https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-8#keyed-di-services).
+*Note: This is not available in version 3.*
+
+You can read more about keyed services in the [.NET 8 Release Notes](https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-8#keyed-di-services).
 
 To register a keyed service, pass a key to the `Key` property of any register attribute:
 ```c#

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-# Dependency Registration Attributes
 Add services to your Service Collection with attributes! Never touch your Program.cs file again!
 
 There are three attributes you can use to register services with your ServiceCollection:

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,7 +1,7 @@
-## Version 8
-### Version 8.0.0
-#### Updates
- - Targetting .NET Standard 2.0.
+# Version 8
+## Version 8.0.0
+### Updates
+ - Targeting .NET Standard 2.0.
  - Adding `Key` and `Tag` properties to all register attributes.
  - The dependency `Microsoft.Extensions.DependencyInjection.Abstractions` has been upgraded to version 8.0.0.
 	- This was to include Keyed service support.
@@ -11,7 +11,7 @@
 	- Errors when a service type is incompatible with the class you are trying to use it with.
 	- Error when a class is invalid (i.e. abstract, static, no public constructors).
 	- Warnings when a Key or Tag has a value that will result in a reference comparison.
-#### Breaking Changes
+### Breaking Changes
  - Tags have been dramatically altered.
 	- These are no longer a constructor argument, instead they are a property.
 	- Only one is allowed per attribute, previously it was unlimmited.
@@ -20,3 +20,75 @@
 	- You will only get tagged services when the tag is explicitly included
 	- You get all untagged services even if you include a tag.
  - Removing extensibility (i.e. ObjectFactory). This was not useful and had very limited use cases.
+
+# Version 7 (Deprecated)
+## Version 7.0.7
+ - Refactoring for readability and efficiency
+ - Fixing analyzer bug, `int` and `string` generic arguments were not being recognized
+ - Removing error analyzer rule for public and internal implementation and service types
+ - Adding open generic support.
+ - Adding lots of documentation.
+ - Reverting project dependencies to Microsoft.Extensions.DependencyInjection.Abstractions, versions 3.1.32 and 8.0.0.
+
+## Version 7.0.6
+ - Reverting back to reflection based registration, removing code generation.
+ - Multi-targeting netstandard2.0 and net8.0.
+ - Updating project dependencies to Microsoft.Extensions.DependencyInjection, versions 3.1.32 and 8.0.0.
+ - New versions of service collection extensions: `AddByAttribute(params object[] tags)` and `AddByAttribute(Assembly, params object[] tags)`
+
+## Version 7.0.5
+ - Adding project with real dll output to hold attributes.
+ - Releasing attribute project, source generator, and analyzer as single project.
+ - Moving service provider extensions to `{project assembly}.DepRegAttributes`
+
+## Version 7.0.4
+ - Fixing `typeof()` arguments for Key or Tag. These were being picked up and used as a service type.
+ - Allowing internal classes to be registered.
+ - Adding warning analyzer for Tags and Keys that are array initializers.
+ - Adding support for generic service types.
+ - Adding warning analyzer for unbound generics.
+ - Updating namespace to the project assembly.
+
+## Version 7.0.3
+ - Fixing nested types, previously the parent class was not being included.
+ - Adding analyzers for private nested types.
+ - Fixing multii-project bug. Projects conflict eachother if generated code is in the same namespace. 
+   - Fixed this by moving all generated code into the project assembly. 
+   - More info here: https://andrewlock.net/creating-a-source-generator-part-7-solving-the-source-generator-marker-attribute-problem-part1/
+
+## Version 7.0.2
+ - Adding Keyed services support.
+ - Added `Key` property on attributes when a project references Microsoft.Extensions.DependencyInjection version 8.0.0 or greater.
+
+## Version 7.0.1
+ - Fixing nuget package tags and target framework
+
+## Version 7.0.0 
+### Updates
+ - Rewrote library to use source generation instead of reflection. *higher chance of bugs*
+ - Added an analyzer that tells a developer when an attribute is invalid.
+ - Changed tag type from `string` to `object`.
+ - Generic arguments are now available in C# 11 langage version, instead of .NET 7.0.
+ - Adding `AddByAttribute()` as an alternative to `RegisterDependenciesByAttribute()`. This is to align more with other common Service Collection extensions.
+### Breaking Changes
+ - Tags are no longer a constructor argument, instead use "Tag" property.
+ - Only one tag is allowed per attribute, before it was unlimited.
+ - Previously if you called `AddByAttribute()` with no tag argument, all services for every tag would be added. This is no longer the case, you will only get services for tags you pass into service collection extension.
+ - Removing extensibility (i.e. ObjectFactory). This was not useful and extremely complex with source generation.
+
+## Version 6 (Deprecated)
+### Version 6.0.0
+ - Adding `ObjectFactory` property in attribute base for extensibility
+
+## Version 5 (Deprecated)
+### Version 5.0.0
+ - Adding multi-targeting for .NET 7.0 and .NET Standard 2.0.
+ - Adding generic attribute arguments for .NET 7.0 target.
+
+## Version 4 (Deprecated)
+### Version 4.0.0
+ - Targeting .NET Standard 2.0 for wider compatibility.
+
+## Version 3 (Deprecated)
+### Version 3.0.0
+ - Automatically registering by matching interface name.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,69 +1,22 @@
-### Version 7.0.8
- - Fixing bug where the obsolete RegisterDependenciesByAttribute function was using the wrong assembly.
- - Targeting .netstandard so the ps1 tools get included in the nuget package.
-
-### Version 7.0.7
- - Refactoring for readability and efficiency
- - Fixing analyzer bug, `int` and `string` generic arguments were not being recognized
- - Removing error analyzer rule for public and internal implementation and service types
- - Adding open generic support.
- - Adding lots of documentation.
- - Reverting project dependencies to Microsoft.Extensions.DependencyInjection.Abstractions, versions 3.1.32 and 8.0.0.
-
-### Version 7.0.6
- - Reverting back to reflection based registration, removing code generation.
- - Multi-targeting netstandard2.0 and net8.0.
- - Updating project dependencies to Microsoft.Extensions.DependencyInjection, versions 3.1.32 and 8.0.0.
- - New versions of service collection extensions: `AddByAttribute(params object[] tags)` and `AddByAttribute(Assembly, params object[] tags)`
-
-### Version 7.0.5
- - Adding project with real dll output to hold attributes.
- - Releasing attribute project, source generator, and analyzer as single project.
- - Moving service provider extensions to `{project assembly}.DepRegAttributes`
-
-### Version 7.0.4
- - Fixing `typeof()` arguments for Key or Tag. These were being picked up and used as a service type.
- - Allowing internal classes to be registered.
- - Adding warning analyzer for Tags and Keys that are array initializers.
- - Adding support for generic service types.
- - Adding warning analyzer for unbound generics.
- - Updating namespace to the project assembly.
-
-### Version 7.0.3
- - Fixing nested types, previously the parent class was not being included.
- - Adding analyzers for private nested types.
- - Fixing multii-project bug. Projects conflict eachother if generated code is in the same namespace. 
-   - Fixed this by moving all generated code into the project assembly. 
-   - More info here: https://andrewlock.net/creating-a-source-generator-part-7-solving-the-source-generator-marker-attribute-problem-part1/
-
-### Version 7.0.2
- - Adding Keyed services support.
- - Added `Key` property on attributes when a project references Microsoft.Extensions.DependencyInjection version 8.0.0 or greater.
-
-### Version 7.0.1
- - Fixing nuget package tags and target framework
-
-### Version 7.0.0 
- - Rewrote library to use source generation instead of reflection. *higher chance of bugs*
- - Added an analyzer that tells a developer when an attribute is invalid.
- - Changed tag type from `string` to `object`.
- - Generic arguments are now available in C# 11 langage version, instead of .NET 7.0.
- - Adding `AddByAttribute()` as an alternative to `RegisterDependenciesByAttribute()`. This is to align more with other common Service Collection extensions.
-#### Breaking Changes:
- - Tags are no longer a constructor argument, instead use "Tag" property.
- - Only one tag is allowed per attribute, before it was unlimited.
- - Previously if you called `AddByAttribute()` with no tag argument, all services for every tag would be added. This is no longer the case, you will only get services for tags you pass into service collection extension.
- - Removing extensibility (i.e. ObjectFactory). This was not useful and extremely complex with source generation.
-
-### Version 6.0.0
- - Adding `ObjectFactory` property in attribute base for extensibility
-
-### Version 5.0.0
- - Adding multi-targeting for .NET 7.0 and .NET Standard 2.0.
- - Adding generic attribute arguments for .NET 7.0 target.
-
-### Version 4.0.0
- - Targeting .NET Standard 2.0 for wider compatibility.
-
-### Version 3.0.0
- - Automatically registering by matching interface name.
+## Version 8
+### Version 8.0.0
+#### Updates
+ - Targetting .NET Standard 2.0.
+ - Adding `Key` and `Tag` properties to all register attributes.
+ - The dependency `Microsoft.Extensions.DependencyInjection.Abstractions` has been upgraded to version 8.0.0.
+	- This was to include Keyed service support.
+ - Adding `AddByAttribute()` service collection extensions to align more with other common naming convensions.
+	- The previous extension `RegisterDependenciesByAttribute()` has been marked as obsolete.
+ - Adding Analyzers
+	- Errors when a service type is incompatible with the class you are trying to use it with.
+	- Error when a class is invalid (i.e. abstract, static, no public constructors).
+	- Warnings when a Key or Tag has a value that will result in a reference comparison.
+#### Breaking Changes
+ - Tags have been dramatically altered.
+	- These are no longer a constructor argument, instead they are a property.
+	- Only one is allowed per attribute, previously it was unlimmited.
+ - Service collection extensions have changed.
+	- When you add services by attribute, you no longer pull in all tagged services when you don't include a tag.
+	- You will only get tagged services when the tag is explicitly included
+	- You get all untagged services even if you include a tag.
+ - Removing extensibility (i.e. ObjectFactory). This was not useful and had very limited use cases.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,6 @@
 ### Version 7.0.8
  - Fixing bug where the obsolete RegisterDependenciesByAttribute function was using the wrong assembly.
- - Targetting .netstandard so the ps1 tools get included in the nuget package.
+ - Targeting .netstandard so the ps1 tools get included in the nuget package.
 
 ### Version 7.0.7
  - Refactoring for readability and efficiency

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,7 @@
+### Version 7.0.8
+ - Fixing bug where the obsolete RegisterDependenciesByAttribute function was using the wrong assembly.
+ - Targetting .netstandard so the ps1 tools get included in the nuget package.
+
 ### Version 7.0.7
  - Refactoring for readability and efficiency
  - Fixing analyzer bug, `int` and `string` generic arguments were not being recognized


### PR DESCRIPTION
### Version 7.0.8
 - Fixing bug where the obsolete RegisterDependenciesByAttribute function was using the wrong assembly.
 - Targeting .netstandard so the ps1 tools get included in the nuget package.