### PR TITLE
Tag update

### DIFF
--- a/DepRegAttributes.ExampleLibrary/RegisteredClasses/TaggedServices/IOverridableService.cs
+++ b/DepRegAttributes.ExampleLibrary/RegisteredClasses/TaggedServices/IOverridableService.cs
@@ -1,0 +1,15 @@
+﻿namespace DepRegAttributes.ExampleLibrary.RegisteredClasses.TaggedServices;
+
+public interface IOverridableService
+{
+}
+
+[RegisterTransient<IOverridableService>]
+public class OverridableUntagged : IOverridableService
+{
+}
+
+[RegisterTransient<IOverridableService>(Tag = "Override")]
+public class OverridableTagged : IOverridableService
+{
+}

--- a/DepRegAttributes.ExampleLibrary/ServiceCollectionExtentions.cs
+++ b/DepRegAttributes.ExampleLibrary/ServiceCollectionExtentions.cs
@@ -8,13 +8,13 @@ namespace DepRegAttributes.ExampleLibrary
     //YOU ONLY NEED TO ADD THIS ONCE FOR A SINGLE PROJECT
     public static class ServiceCollectionExtentions
     {
-        public static IServiceCollection AddExampleLibraryRegistration(this IServiceCollection services, params object[] includeTags)
+        public static IServiceCollection AddExampleLibrary(this IServiceCollection services, object? tagFilter = null)
         {
             //This will automatically load all dependancies of the
             //assembly we are currently in. Alternatively you can
             //call this once and pass it all of the assemblies you
             //want to load
-            return services.AddByAttribute(includeTags);
+            return services.AddByAttribute(tagFilter);
         }
     }
 }

--- a/DepRegAttributes.Tests/ExternalResourceTests.cs
+++ b/DepRegAttributes.Tests/ExternalResourceTests.cs
@@ -1,8 +1,4 @@
-﻿using DepRegAttributes.ExampleLibrary.RegisteredClasses.ExternalReferences;
-using DepRegAttributes.ExampleLibrary.RegisteredClasses.TaggedServices;
-using DepRegAttributes.ExternalExampleLibrary;
-using DepRegAttributes.ExternalExampleLibrary.SubNamespace;
-namespace DepRegAttributes.Tests;
+﻿namespace DepRegAttributes.Tests;
 
 [TestClass]
 public class ExternalResourceTests : UnitTestBase
@@ -11,7 +7,9 @@ public class ExternalResourceTests : UnitTestBase
     public void GetFromExternalInterface()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var service = sut.GetService<IExternalInterface>();
@@ -24,7 +22,9 @@ public class ExternalResourceTests : UnitTestBase
     public void GetFromExternalInterfaceWithNamespace()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var service = sut.GetService<IExternalInterfaceInNamespace>();
@@ -37,7 +37,9 @@ public class ExternalResourceTests : UnitTestBase
     public void GetTaggedWithExternalenum()
     {
         //Arrange
-        var sut = CreateSut(ExternalEnum.Value);
+        var sut = new ServiceCollection()
+            .AddExampleLibrary(ExternalEnum.Value)
+            .BuildServiceProvider();
 
         //Act
         var service = sut.GetService<TaggedWithExternalEnum>();
@@ -50,7 +52,9 @@ public class ExternalResourceTests : UnitTestBase
     public void GetTaggedWithExternalConst()
     {
         //Arrange
-        var sut = CreateSut(ExternalConst.Value);
+        var sut = new ServiceCollection()
+            .AddExampleLibrary(ExternalConst.Value)
+            .BuildServiceProvider();
 
         //Act
         var service = sut.GetService<TaggedWithExternalConst>();

--- a/DepRegAttributes.Tests/KeyedRegistrationTests.cs
+++ b/DepRegAttributes.Tests/KeyedRegistrationTests.cs
@@ -9,7 +9,9 @@ public class KeyedRegistrationTests : UnitTestBase
     public void GetKeyedSingletonWithMultipleInterfacesTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var service1 = sut.GetKeyedService<IKeyedInterface>(Const.Value);
@@ -25,7 +27,9 @@ public class KeyedRegistrationTests : UnitTestBase
     public void GetArrayKeyedTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var service = sut.GetKeyedService<KeyedWithArray>(new[] { "Value1", "Value2" });
@@ -38,7 +42,9 @@ public class KeyedRegistrationTests : UnitTestBase
     public void DontGetConstKeyedTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var service = sut.GetService<KeyedWithConst>();
@@ -51,7 +57,9 @@ public class KeyedRegistrationTests : UnitTestBase
     public void GetConstKeyedTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var service = sut.GetKeyedService<KeyedWithConst>(Const.Value);
@@ -64,7 +72,9 @@ public class KeyedRegistrationTests : UnitTestBase
     public void GetEnumKeyedTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var service = sut.GetKeyedService<KeyedWithEnum>(TagEnum.TagExample);
@@ -77,7 +87,9 @@ public class KeyedRegistrationTests : UnitTestBase
     public void GetIntKeyedTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var service = sut.GetKeyedService<KeyedWithInt>(100);
@@ -90,7 +102,9 @@ public class KeyedRegistrationTests : UnitTestBase
     public void GetKeyedWithInterfaceTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var service = sut.GetKeyedService<IKeyedWithInterface>("Value");
@@ -103,7 +117,9 @@ public class KeyedRegistrationTests : UnitTestBase
     public void GetKeyedWithInternalConstTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var service = sut.GetKeyedService<KeyedWithInternalConst>(KeyedWithInternalConst.Value);
@@ -116,7 +132,9 @@ public class KeyedRegistrationTests : UnitTestBase
     public void GetKeyedWithInternalPrivateConstTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var service = sut.GetKeyedService<KeyedWithInternalPrivateConst>("Value");
@@ -129,7 +147,9 @@ public class KeyedRegistrationTests : UnitTestBase
     public void GetStringKeyedTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var service = sut.GetKeyedService<KeyedWithString>("Value");
@@ -142,7 +162,9 @@ public class KeyedRegistrationTests : UnitTestBase
     public void GetTypeKeyedTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var service = sut.GetKeyedService<IKeyedWithType>(typeof(TypeKey));
@@ -155,7 +177,9 @@ public class KeyedRegistrationTests : UnitTestBase
     public void GetKeyedAndTagged()
     {
         //Arrange
-        var sut = CreateSut(TagEnum.TagExample);
+        var sut = new ServiceCollection()
+            .AddExampleLibrary(TagEnum.TagExample)
+            .BuildServiceProvider();
 
         //Act
         var service = sut.GetKeyedService<KeyedAndTagged>(Const.Value);
@@ -168,7 +192,9 @@ public class KeyedRegistrationTests : UnitTestBase
     public void DontGetKeyedAndTagged()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var service = sut.GetKeyedService<KeyedAndTagged>(Const.Value);

--- a/DepRegAttributes.Tests/NestedServicesTests.cs
+++ b/DepRegAttributes.Tests/NestedServicesTests.cs
@@ -1,6 +1,4 @@
-﻿using DepRegAttributes.ExampleLibrary.RegisteredClasses.NestedServices;
-
-namespace DepRegAttributes.Tests;
+﻿namespace DepRegAttributes.Tests;
 
 [TestClass]
 public class NestedServicesTests : UnitTestBase
@@ -9,7 +7,9 @@ public class NestedServicesTests : UnitTestBase
     public void GetNestedServiceTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var service = sut.GetService<ParentService.NestedService>();
@@ -22,7 +22,9 @@ public class NestedServicesTests : UnitTestBase
     public void GetNestedServiceWithInterfaceTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var service = sut.GetService<ParentService.INestedServiceWithInterface>();
@@ -35,7 +37,9 @@ public class NestedServicesTests : UnitTestBase
     public void GetDoubleNestedServiceTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var service = sut.GetService<ParentService.MiddleService.DoubleNestedService>();

--- a/DepRegAttributes.Tests/OpenGenericTests.cs
+++ b/DepRegAttributes.Tests/OpenGenericTests.cs
@@ -1,6 +1,4 @@
-﻿using DepRegAttributes.ExampleLibrary.RegisteredClasses.OpenGenerics;
-
-namespace DepRegAttributes.Tests;
+﻿namespace DepRegAttributes.Tests;
 
 [TestClass]
 public class OpenGenericTests : UnitTestBase
@@ -9,7 +7,9 @@ public class OpenGenericTests : UnitTestBase
     public void GetGenericTransientTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var transientInt = sut.GetRequiredService<TransientOpenGeneric<int>>();
@@ -26,7 +26,9 @@ public class OpenGenericTests : UnitTestBase
     public void GetGenericTransientInterfaceTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var transientInt = sut.GetRequiredService<ITransientOpenGeneric<int>>();
@@ -43,7 +45,9 @@ public class OpenGenericTests : UnitTestBase
     public void GetMutipleGenericTransientTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var transientInt = sut.GetRequiredService<TransientOpenMultipleGeneric<int, string>>();
@@ -60,7 +64,9 @@ public class OpenGenericTests : UnitTestBase
     public void GetMutipleGenericTransientInterfaceTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var transientInt = sut.GetRequiredService<ITransientOpenMultipleGeneric<int, string>>();

--- a/DepRegAttributes.Tests/SingletonRegistrarionTests.cs
+++ b/DepRegAttributes.Tests/SingletonRegistrarionTests.cs
@@ -7,7 +7,9 @@ public class SingletonRegistrarionTests : UnitTestBase
     public void GetSingletonTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var singleton = sut.GetRequiredService<SingletonClassRegisteredAsSelf>();
@@ -22,7 +24,9 @@ public class SingletonRegistrarionTests : UnitTestBase
     public void GetMultipleSingletonsTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var singleton1 = sut.GetRequiredService<SingletonClassRegisteredAsSelf>();
@@ -38,7 +42,9 @@ public class SingletonRegistrarionTests : UnitTestBase
     public void GetSingletonFromMultipleInterfacesTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var singleton1 = sut.GetRequiredService<ISingletonClassWithMultipleInterfaces>();
@@ -54,7 +60,9 @@ public class SingletonRegistrarionTests : UnitTestBase
     public void GetSingletonFromMultipleInterfacesGenericTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var singleton1 = sut.GetRequiredService<ISingletonClassWithMultipleInterfacesGeneric>();
@@ -70,7 +78,9 @@ public class SingletonRegistrarionTests : UnitTestBase
     public void GetSingletonGroupsTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var singletonGroup1 = sut.GetRequiredService<ISingletonGroup1>();
@@ -97,7 +107,9 @@ public class SingletonRegistrarionTests : UnitTestBase
     public void GetSingletonFromSingleInterfaceTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var singleton1 = sut.GetRequiredService<ISingletonClassWithOneInterface>();

--- a/DepRegAttributes.Tests/TaggedRegistrationTests.cs
+++ b/DepRegAttributes.Tests/TaggedRegistrationTests.cs
@@ -1,6 +1,4 @@
-﻿using DepRegAttributes.ExampleLibrary.RegisteredClasses.KeyedServices;
-using DepRegAttributes.ExampleLibrary.RegisteredClasses.TaggedServices;
-namespace DepRegAttributes.Tests;
+﻿namespace DepRegAttributes.Tests;
 
 [TestClass]
 public class TaggedRegistrationTests : UnitTestBase
@@ -9,7 +7,9 @@ public class TaggedRegistrationTests : UnitTestBase
     public void GetTaggedOneTest()
     {
         //Arrange
-        var sut = CreateSut("One");
+        var sut = new ServiceCollection()
+            .AddExampleLibrary("One")
+            .BuildServiceProvider();
         
         //Act
         var one = sut.GetService<TaggedOne>();
@@ -28,7 +28,9 @@ public class TaggedRegistrationTests : UnitTestBase
     public void GetTaggedTwoTest()
     {
         //Arrange
-        var sut = CreateSut("Two");
+        var sut = new ServiceCollection()
+            .AddExampleLibrary("Two")
+            .BuildServiceProvider();
 
         //Act
         var one = sut.GetService<TaggedOne>();
@@ -47,8 +49,13 @@ public class TaggedRegistrationTests : UnitTestBase
     public void GetMultiTaggedTest()
     {
         //Arrange
-        var sut1 = CreateSut("One");
-        var sut2 = CreateSut("Two");
+        var sut1 = new ServiceCollection()
+            .AddExampleLibrary("One")
+            .BuildServiceProvider();
+
+        var sut2 = new ServiceCollection()
+            .AddExampleLibrary("Two")
+            .BuildServiceProvider();
 
         //Act
         var untagged1 = sut1.GetService<TaggedOneTwo>();
@@ -64,26 +71,12 @@ public class TaggedRegistrationTests : UnitTestBase
     }
 
     [TestMethod]
-    public void GetUntaggedTest()
-    {
-        //Arrange
-        var sut1 = CreateSut("One");
-        var sut2 = CreateSut("Two");
-
-        //Act
-        var untagged1 = sut1.GetService<TaggedNothing>();
-        var untagged2 = sut2.GetService<TaggedNothing>();
-
-        //Assert
-        Assert.IsNotNull(untagged1);
-        Assert.IsNotNull(untagged2);
-    }
-
-    [TestMethod]
     public void GetEnumTagged()
     {
         //Arrange
-        var sut = CreateSut(TagEnum.TagExample);
+        var sut = new ServiceCollection()
+            .AddExampleLibrary(TagEnum.TagExample)
+            .BuildServiceProvider();
 
         //Act
         var service = sut.GetService<TaggedWithEnum>();
@@ -96,7 +89,9 @@ public class TaggedRegistrationTests : UnitTestBase
     public void GetConstTagged()
     {
         //Arrange
-        var sut = CreateSut(Const.Value);
+        var sut = new ServiceCollection()
+            .AddExampleLibrary(Const.Value)
+            .BuildServiceProvider();
 
         //Act
         var service = sut.GetService<TaggedWithConst>();
@@ -109,7 +104,9 @@ public class TaggedRegistrationTests : UnitTestBase
     public void GetIntTagged()
     {
         //Arrange
-        var sut = CreateSut(100);
+        var sut = new ServiceCollection()
+            .AddExampleLibrary(100)
+            .BuildServiceProvider();
 
         //Act
         var service = sut.GetService<TaggedWithInt>();
@@ -122,7 +119,9 @@ public class TaggedRegistrationTests : UnitTestBase
     public void GetInternalConstTagged()
     {
         //Arrange
-        var sut = CreateSut(TaggedWithInternalConst.Value);
+        var sut = new ServiceCollection()
+            .AddExampleLibrary(TaggedWithInternalConst.Value)
+            .BuildServiceProvider();
 
         //Act
         var service = sut.GetService<TaggedWithInternalConst>();
@@ -135,7 +134,9 @@ public class TaggedRegistrationTests : UnitTestBase
     public void GetInternalPrivateConstTagged()
     {
         //Arrange
-        var sut = CreateSut("Value");
+        var sut = new ServiceCollection()
+            .AddExampleLibrary("Value")
+            .BuildServiceProvider();
 
         //Act
         var service = sut.GetService<TaggedWithInternalPrivateConst>();
@@ -147,9 +148,11 @@ public class TaggedRegistrationTests : UnitTestBase
     [TestMethod]
     public void GetArrayTagged()
     {
-        //Arrange
-        var sut = CreateSut(new[] { "Value1", "Value2" });
         //Note, this is possible, but you will not be able to get any services tagged this way
+        //Arrange
+        var sut = new ServiceCollection()
+            .AddExampleLibrary(new[] { "Value1", "Value2" })
+            .BuildServiceProvider();
 
         //Act
         var service = sut.GetService<TaggedWithArray>();
@@ -162,7 +165,9 @@ public class TaggedRegistrationTests : UnitTestBase
     public void GetTypeTagged()
     {
         //Arrange
-        var sut = CreateSut(typeof(TypeTag));
+        var sut = new ServiceCollection()
+            .AddExampleLibrary(typeof(TypeTag))
+            .BuildServiceProvider();
 
         //Act
         var service = sut.GetService<ITaggedWithType>();
@@ -172,10 +177,12 @@ public class TaggedRegistrationTests : UnitTestBase
     }
 
     [TestMethod]
-    public void EnsureTaggedNotPresentInUntaggerRegistration()
+    public void EnsureTaggedNotPresentInUnfilteredRegistration()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var one = sut.GetService<TaggedOne>();
@@ -193,4 +200,78 @@ public class TaggedRegistrationTests : UnitTestBase
         Assert.IsNull(interfaceOneTwo);
         Assert.IsNull(enumTag);
     }
+
+    [TestMethod]
+    public void EnsureUtaggedNotPresentInFilteredRegistration()
+    {
+        //Arrange
+        var sut = new ServiceCollection()
+            .AddExampleLibrary("Misc. Tag")
+            .BuildServiceProvider();
+
+        //Act
+        var untagged = sut.GetService<TaggedNothing>();
+        var transient = sut.GetService<ITransientClassWithOneInterface>();
+
+        //Assert
+        Assert.IsNull(untagged);
+        Assert.IsNull(transient);
+    }
+
+    [TestMethod]
+    public void RegisterTaggedAndUntaggedTest()
+    {
+        //Arrange
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .AddExampleLibrary("One")
+            .BuildServiceProvider();
+
+        //Act
+        var one = sut.GetService<TaggedOne>();
+        var oneTwo = sut.GetService<TaggedOneTwo>();
+        var untagged = sut.GetService<TaggedNothing>();
+        var transient = sut.GetService<ITransientClassWithOneInterface>();
+
+        //Assert
+        Assert.IsNotNull(one);
+        Assert.IsNotNull(oneTwo);
+        Assert.IsNotNull(untagged);
+        Assert.IsNotNull(transient);
+    }
+
+    [TestMethod]
+    public void OverrideByTaggedServiceTest()
+    {
+        //Arrange
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .AddExampleLibrary("Override")
+            .BuildServiceProvider();
+
+        //Act
+        var overrodeService = sut.GetService<IOverridableService>();
+
+        //Assert
+        Assert.IsInstanceOfType(overrodeService, typeof(OverridableTagged));
+        Assert.IsNotInstanceOfType(overrodeService, typeof(OverridableUntagged));
+    }
+
+    [TestMethod]
+    public void EnsureOverridableServiceExists()
+    {
+        //Arrange
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
+
+        //Act
+        var overrodeService = sut.GetService<IOverridableService>();
+
+        //Assert
+        Assert.IsNotInstanceOfType(overrodeService, typeof(OverridableTagged));
+        Assert.IsInstanceOfType(overrodeService, typeof(OverridableUntagged));
+    }
+
+
 }

--- a/DepRegAttributes.Tests/TransientRegistrarionTests.cs
+++ b/DepRegAttributes.Tests/TransientRegistrarionTests.cs
@@ -1,6 +1,4 @@
-﻿using DepRegAttributes.ExampleLibrary.Test;
-
-namespace DepRegAttributes.Tests;
+﻿namespace DepRegAttributes.Tests;
 
 [TestClass]
 public class TransientRegistrarionTests : UnitTestBase
@@ -9,7 +7,9 @@ public class TransientRegistrarionTests : UnitTestBase
     public void GetTransientTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var transient = sut.GetRequiredService<TransientClassRegisteredAsSelf>();
@@ -22,7 +22,9 @@ public class TransientRegistrarionTests : UnitTestBase
     public void GetMultipleTransientsTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var transient1 = sut.GetRequiredService<TransientClassRegisteredAsSelf>();
@@ -38,7 +40,9 @@ public class TransientRegistrarionTests : UnitTestBase
     public void GetTransientFromMultipleInterfacesTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var transient1 = sut.GetRequiredService<ITransientClassWithMultipleIntefaces>();
@@ -54,7 +58,9 @@ public class TransientRegistrarionTests : UnitTestBase
     public void GetTransientFromMultipleInterfacesGenricTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var transient1 = sut.GetRequiredService<ITransientClassWithMultipleIntefacesGeneric>();
@@ -70,7 +76,9 @@ public class TransientRegistrarionTests : UnitTestBase
     public void GetTransientFromSingleInterfaceTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var transient1 = sut.GetRequiredService<ITransientClassWithOneInterface>();
@@ -87,7 +95,9 @@ public class TransientRegistrarionTests : UnitTestBase
     public void GetTransientWithTypedInterfaceTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var transient = sut.GetRequiredService<ITransientClassWithTypedInterface<string>>();
@@ -101,7 +111,9 @@ public class TransientRegistrarionTests : UnitTestBase
     public void GetTransientWithTypedInterfaceInOtherNamespaceTest()
     {
         //Arrange
-        var sut = CreateSut();
+        var sut = new ServiceCollection()
+            .AddExampleLibrary()
+            .BuildServiceProvider();
 
         //Act
         var transient = sut.GetRequiredService<ITransientClassWithTypedInterface<ITypeInOtherNamespace>>();

--- a/DepRegAttributes.Tests/UnitTestBase.cs
+++ b/DepRegAttributes.Tests/UnitTestBase.cs
@@ -3,9 +3,4 @@
 public abstract class UnitTestBase
 {
     public TestContext TestContext { get; set; } = null!;
-
-    public IServiceProvider CreateSut(params object[] includeTags)
-        => new ServiceCollection()
-            .AddExampleLibraryRegistration(includeTags)
-            .BuildServiceProvider();
 }

--- a/DepRegAttributes.Tests/Usings.cs
+++ b/DepRegAttributes.Tests/Usings.cs
@@ -3,4 +3,12 @@ global using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 global using DepRegAttributes.ExampleLibrary;
 global using DepRegAttributes.ExampleLibrary.RegisteredClasses;
+global using DepRegAttributes.ExampleLibrary.RegisteredClasses.ExternalReferences;
+global using DepRegAttributes.ExampleLibrary.RegisteredClasses.NestedServices;
+global using DepRegAttributes.ExampleLibrary.RegisteredClasses.OpenGenerics;
+global using DepRegAttributes.ExampleLibrary.RegisteredClasses.TaggedServices;
+global using DepRegAttributes.ExampleLibrary.Test;
+
+global using DepRegAttributes.ExternalExampleLibrary;
+global using DepRegAttributes.ExternalExampleLibrary.SubNamespace;
 

--- a/DepRegAttributes/DepRegAttributes.csproj
+++ b/DepRegAttributes/DepRegAttributes.csproj
@@ -11,7 +11,7 @@
 	<PropertyGroup>
 		<PackageId>DBaker.DepRegAttributes</PackageId>
 		<Authors>dalton_s_baker</Authors>
-		<Version>8.0.0</Version>
+		<Version>8.0.1</Version>
 		<PackageProjectUrl>https://github.com/dalton-baker/DepRegAttributes</PackageProjectUrl>
 		<!--<PackageIconUrl>http://ICON_URL_HERE_OR_DELETE_THIS_LINE</PackageIconUrl>-->
 		<RepositoryUrl>https://github.com/dalton-baker/DepRegAttributes</RepositoryUrl>

--- a/DepRegAttributes/RegisterAttributeBase.cs
+++ b/DepRegAttributes/RegisterAttributeBase.cs
@@ -14,7 +14,7 @@ public abstract class RegisterAttributeBase(ServiceLifetime serviceLifetime, par
     /// <summary>
     /// Used as a filter when registering services
     /// </summary>
-    public object? Tag { get; set; }
+    public object? Tag { get; set; } = null;
     
     /// <summary>
     /// Use this to register a Keyed service 

--- a/DepRegAttributes/ServiceCollectionExtensions.cs
+++ b/DepRegAttributes/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 
 namespace DepRegAttributes;
@@ -13,56 +14,56 @@ public static class ServiceCollectionExtensions
     /// Register services by attribute for your current Assembly.
     /// </summary>
     /// <param name="services">The Service Collection</param>
-    /// <param name="tagFilters">The tags you want to register services for (optional)</param>
+    /// <param name="tagFilter">The tag you want to register services for (optional)</param>
     /// <exception cref="CustomAttributeFormatException">Thrown when an attribute has a service type that is not valid for the implementation type.</exception>
     /// <returns>A reference to this instance after the opperation has completed.</returns>
     [Obsolete("Use AddByAttribute()")]
     public static IServiceCollection RegisterDependenciesByAttribute(
         this IServiceCollection services,
-        params object[] tagFilters)
-        => services.AddByAttribute(Assembly.GetCallingAssembly(), tagFilters);
+        object? tagFilter = null)
+        => services.AddByAttribute(Assembly.GetCallingAssembly(), tagFilter);
 
     /// <summary>
     /// Register services by attribute for a specific Assembly.
     /// </summary>
     /// <param name="services">The service Collection</param>
     /// <param name="assembly">The Assembly you are registering services from</param>
-    /// <param name="tagFilters">The tags you want to register services for (optional)</param>
+    /// <param name="tagFilter">The tag you want to register services for (optional)</param>
     /// <exception cref="CustomAttributeFormatException">Thrown when an attribute has a service type that is not valid for the implementation type.</exception>
     /// <returns>A reference to this instance after the opperation has completed.</returns>
     [Obsolete("Use AddByAttribute()")]
     public static IServiceCollection RegisterDependenciesByAttribute(
         this IServiceCollection services,
         Assembly assembly,
-        params object[] tagFilters)
-        => services.AddByAttribute(assembly, tagFilters);
+        object? tagFilter = null)
+        => services.AddByAttribute(assembly, tagFilter);
 
     /// <summary>
     /// Register services by attribute for your current Assembly.
     /// </summary>
     /// <param name="services">The service Collection</param>
-    /// <param name="tagFilters">The tags you want to register services for (optional)</param>
+    /// <param name="tagFilter">The tag you want to register services for (optional)</param>
     /// <exception cref="CustomAttributeFormatException">Thrown when an attribute has a service type that is not valid for the implementation type.</exception>
     /// <returns>A reference to this instance after the opperation has completed.</returns>
     public static IServiceCollection AddByAttribute(
         this IServiceCollection services,
-        params object[] tagFilters)
+        object? tagFilter = null)
         => services.AddByAttribute(
             Assembly.GetCallingAssembly(),
-            tagFilters);
+            tagFilter);
 
     /// <summary>
     /// Register services by attribute for a specific Assembly.
     /// </summary>
     /// <param name="services">The service Collection</param>
     /// <param name="assembly">The Assembly you are registering services from</param>
-    /// <param name="tagFilters">The tags you want to register services for (optional)</param>
+    /// <param name="tagFilter">The tag you want to register services for (optional)</param>
     /// <exception cref="CustomAttributeFormatException">Thrown when an attribute has a service type that is not valid for the implementation type.</exception>
     /// <returns>A reference to this instance after the opperation has completed.</returns>
     public static IServiceCollection AddByAttribute(
         this IServiceCollection services,
         Assembly assembly,
-        params object[] tagFilters)
+        object? tagFilter = null)
     {
         foreach (Type implementationType in assembly.GetTypes())
         {
@@ -70,7 +71,7 @@ public static class ServiceCollectionExtensions
             {
                 if(attribute is RegisterAttributeBase registerAttribute)
                 {
-                    if (registerAttribute.Tag is not null && Array.IndexOf(tagFilters, registerAttribute.Tag) < 0)
+                    if (!EqualityComparer<object?>.Default.Equals(tagFilter, registerAttribute.Tag))
                         continue;
 
                     services.AddServiceForAttribute(implementationType, registerAttribute);

--- a/README.md
+++ b/README.md
@@ -115,11 +115,11 @@ public class ExampleService : IExampleService, IAnotherExampleService
 Tags can be used to register services conditionally when building your service collection.
 
 Tags are objects, so you can use anything as long as it can be passed as an attribute argument. This limits them to constants (i.e. strings, enums, numbers).
+```c#
+serviceCollection.AddByAttribute("Example");
+serviceCollection.AddByAttribute(14);
+serviceCollection.AddByAttribute(ExampleEnum.ExampleValue);
 ```
-serviceCollection.AddByAttribute("Example", 14, ExampleEnum.ExampleValue);
-```
-
-Untagged services will always be included, even when passing tags to the AddByAttribute function. Services are registered in the same order as their attributes, keep this in mind if you have a service that is registered as tagged and untagged. You will want the tagged attribute bellow the untagged attribute, since the untagged attribute will be included all the time.
 
 Define tags via the Tag property on attributes:
 ```c#
@@ -127,17 +127,22 @@ Define tags via the Tag property on attributes:
 public class ExampleService
 {
     //Equivalent:
-    //if(includedTag.Equals("Example"))
+    //if(tagFilter.Equals("Example"))
     //{
     //    serviceCollection.AddTransient<ExampleService>();
     //}
 }
 ```
-If you are using tags and want to register services form a specific assembly, pass the assembly as the first argument:
-```
-serviceCollection.AddByAttribute(assembly, "Key1", "Key2");
-```
 
+When using tagged services you will need to call `AddByAttribute` multiple times, once for your untagged services, then once for each tag.
+```c#
+//Add untagged services
+serviceCollection.AddByAttribute();
+//Add services tagged with 'ExampleEnum.ExampleValue'
+serviceCollection.AddByAttribute(ExampleEnum.ExampleValue);
+//Add services tagged with '14'
+serviceCollection.AddByAttribute(14);
+```
 
 ## Keyed Services
 *Note: This is not available in version 3.*
@@ -165,7 +170,7 @@ public class ExampleService<T>
 }
 ```
 
-Unbound generics do not automatically register matching interface types, so you will have to do it manually:
+Unbound generics do not automatically register with matching interfaces, so you need to specify them explicitly:
 ```c#
 [RegisterTransient(typeof(IExampleService<>))]
 public class ExampleService<T> : IExampleService<T>
@@ -174,5 +179,5 @@ public class ExampleService<T> : IExampleService<T>
     //serviceCollection.AddTransient(typeof(IExampleService<>), typeof(ExampleService<>));
 }
 ```
-*Note: You must use `typeof()` arguments when doing this, you cannot pass an unbound generic as a generic argument.*
+*Note: You must use `typeof()` arguments when doing this, you cannot pass an unbound generic as a generic argument.*  
 *Note 2: There is no analyzer support for unbound generics, failures will only appear at runtime.*

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ serviceCollection.AddByAttribute(assembly, "Key1", "Key2");
 ## Keyed Services
 *Note: This is not available in version 3.*
 
-You can read more about keyed services in the [.NET 8 Release Notes](https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-8#keyed-di-services).
+You can read more about keyed services in the [.NET 8 Release Notes](https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-8/runtime#keyed-di-services).
 
 To register a keyed service, pass a key to the `Key` property of any register attribute:
 ```c#

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,4 +1,16 @@
 # Version 8
+
+## Version 8.0.1
+### Updates
+ - Changing `AddByAttribute` extension take a single optional tag filter instead of a list of tag filters.
+   - Was `AddByAttribute(params object[] tagFilters)`.
+   - Now `AddByAttribute(object? tagFilter = null)`.
+
+### Breaking Changes
+ - When calling `AddByAttribute` only services with a specified tag filter will be registered. Previously it would register all untagged services when a tag was passed in.
+   - This means you will need to call `AddByAttribute` multiple times if you are using tags. Once with no tag filter (this will register all untagged services), then once for each tag you want to register.
+   - This change was made mainly to make tags easier to understand. Also, the `params` parameter didn't allow you to specify the order that tagged services were registered in. 
+
 ## Version 8.0.0
 ### Updates
  - Targeting .NET Standard 2.0.


### PR DESCRIPTION
### Updates
 - Changing `AddByAttribute` extension take a single optional tag filter instead of a list of tag filters.
   - Was `AddByAttribute(params object[] tagFilters)`.
   - Now `AddByAttribute(object? tagFilter = null)`.

### Breaking Changes
 - When calling `AddByAttribute` only services with a specified tag filter will be registered. Previously it would register all untagged services when a tag was passed in.
   - This means you will need to call `AddByAttribute` multiple times if you are using tags. Once with no tag filter (this will register all untagged services), then once for each tag you want to register.
   - This change was made mainly to make tags easier to understand. Also, the `params` parameter didn't allow you to specify the order that tagged services were registered in. 
